### PR TITLE
Feature/delivery refacotr

### DIFF
--- a/common/src/main/java/exception/ErrorCode.java
+++ b/common/src/main/java/exception/ErrorCode.java
@@ -58,6 +58,9 @@ public enum ErrorCode {
 	INVALID_DELIVERY_AGENT(HttpStatus.BAD_REQUEST, "현재 남은 배달 담당자가 없습니다.", "D003"),
 	DELIVERY_AGENT_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "해당 Delivery ID로 배달 담당자를 찾을 수 없습니다.", "D004"),
 	DELIVERY_AGENT_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배달 담당자 삭제에 실패했습니다.", "D005"),
+	INVALID_HUB_ID(HttpStatus.BAD_REQUEST, "허브 ID가 유효하지 않습니다.", "D006"),
+	MISSING_HUB_ID(HttpStatus.BAD_REQUEST, "허브 담당자는 허브 ID가 필요합니다.", "D007"),
+	HUB_MISMATCH(HttpStatus.BAD_REQUEST, "허브 담당자의 소속 허브와 경로 허브가 일치하지 않습니다.", "D008"),
 
 	// 허브 오류
 	HUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 허브입니다.", "H001"),

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryAgentService.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryAgentService.java
@@ -27,12 +27,8 @@ public class DeliveryAgentService {
 
 	private final DeliveryAgentRepository deliveryAgentRepository;
 
-	//TODO: 추후 동기방식으로 boolean 값으로 검증 하고 저장함
-	// 유저에서 DeliveryAgent 을 생성
 	public CreateDeliveryAgentResponse createDeliveryAgent(CreateDeliveryAgentRequest request) {
 
-		// 1. 추후 hubService 에서 ID 검증을 해봐야함
-		// 2. useService 에서도 ID 검증을 해봐야함
 		DeliveryAgent deliveryAgent = DeliveryAgent.builder()
 			.hubId(request.getHubId())
 			.userId(request.getUserId())
@@ -45,35 +41,24 @@ public class DeliveryAgentService {
 	}
 
 	public GetDeliveryAgentResponse getDeliveryAgent(UUID id) {
-		DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(id).orElseThrow(
-			() -> new DeliveryAgentNotFoundException(ErrorCode.DELIVERY_AGENT_NOT_FOUND)
-		);
+		DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(id)
+			.orElseThrow(() -> new DeliveryAgentNotFoundException(ErrorCode.DELIVERY_AGENT_NOT_FOUND));
 
 		return GetDeliveryAgentResponse.fromEntity(deliveryAgent);
 	}
 
-	//TODO: 적당한 담당자 찾는 로직 구현
-	public void handleRouteCreated() {
-		// 1. 적당한 담당자 찾기
-		// 2. 배차정보 set
-		// 3. DB저장
-		// 4. Delivery로 이벤트 발행 --> 그러면 Delivery 상태 변경
-	}
-
 	@Transactional
 	public void updateDeliveryAgentType(UpdateDeliveryTypeRequest request) {
-		DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(request.getDeliveryAgentId()).orElseThrow(
-			() -> new DeliveryAgentNotFoundException(ErrorCode.DELIVERY_AGENT_NOT_FOUND)
-		);
+		DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(request.getDeliveryAgentId())
+			.orElseThrow(() -> new DeliveryAgentNotFoundException(ErrorCode.DELIVERY_AGENT_NOT_FOUND));
 
 		deliveryAgent.updateDeliveryAgentType(request.getDeliveryAgentType());
 	}
 
 	@Transactional
 	public void deleteDeliveryAgent(UUID id) {
-		DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(id).orElseThrow(
-			() -> new DeliveryAgentNotFoundException(ErrorCode.DELIVERY_AGENT_NOT_FOUND)
-		);
+		DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(id)
+			.orElseThrow(() -> new DeliveryAgentNotFoundException(ErrorCode.DELIVERY_AGENT_NOT_FOUND));
 
 		if (deliveryAgent.getDeliveryAgentStatus() == DeliveryAgentStatus.IN_DELIVERY) {
 			throw new InvalidDeliveryAgentException(ErrorCode.INVALID_DELIVERY_AGENT_STATUS);
@@ -104,12 +89,8 @@ public class DeliveryAgentService {
 		List<DeliveryAgent> agents = deliveryAgentRepository.findByDeliveryId(deliveryId);
 
 		return agents.stream()
-			.map(agent -> new DeliveryAgentDto(
-				agent.getDeliveryAgentId(),
-				agent.getDeliveryAgentStatus().name(),
-				agent.getSequence(),
-				null
-			))
+			.map(agent -> new DeliveryAgentDto(agent.getDeliveryAgentId(), agent.getDeliveryAgentStatus().name(),
+				agent.getSequence(), null))
 			.toList();
 	}
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryDispatchService.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryDispatchService.java
@@ -9,11 +9,13 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.eighteenthstreet.deliveryagentservice.application.client.HubFeignClient;
 import com.eighteenthstreet.deliveryagentservice.domain.event.DeliveryAgentAssignedEvent;
 import com.eighteenthstreet.deliveryagentservice.domain.event.RouteCreatedEvent;
 import com.eighteenthstreet.deliveryagentservice.domain.exception.InvalidDeliveryAgentException;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgent;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentStatus;
+import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentType;
 import com.eighteenthstreet.deliveryagentservice.domain.repository.DeliveryAgentRepository;
 
 import exception.ErrorCode;
@@ -27,6 +29,7 @@ public class DeliveryDispatchService {
 	private final DeliveryAgentRepository deliveryAgentRepository;
 	private final AtomicInteger roundRobinIdx = new AtomicInteger(0);
 	private final RabbitTemplate rabbitTemplate;
+	private final HubFeignClient hubFeignClient;
 
 	@Value("${message.queue.delivery-assigned}")
 	private String deliveryAssignedQueue;
@@ -39,20 +42,17 @@ public class DeliveryDispatchService {
 		log.info("배달담당서비스 요청 받음: {}", event);
 
 		try {
-
-			// 1. 사용 가능한 배달 담당자 목록 조회
-			List<DeliveryAgent> availableAgents = deliveryAgentRepository.findByDeliveryAgentStatus(
-				DeliveryAgentStatus.AVAILABLE);
-			if (availableAgents.isEmpty()) {
-				throw new InvalidDeliveryAgentException(ErrorCode.INVALID_DELIVERY_AGENT);
-
-			}
-			log.info("사용 가능한 담당자 수: {}", availableAgents.size());
-
-			// 2. 라운드 로빈으로 경로 배치
+			// 각 경로별로 배차
 			List<RouteCreatedEvent.RouteInfo> routes = event.routes();
 			for (RouteCreatedEvent.RouteInfo route : routes) {
-				// 라운드 로빈 인덱스 계산
+				// 1. 사용 가능한 배달 담당자 목록 조회 (hubId 기반)
+				List<DeliveryAgent> availableAgents = getAvailableAgentsForRoute(route);
+				if (availableAgents.isEmpty()) {
+					throw new InvalidDeliveryAgentException(ErrorCode.INVALID_DELIVERY_AGENT);
+				}
+				log.info("사용 가능한 담당자 수: {}", availableAgents.size());
+
+				// 2. 라운드 로빈으로 경로 배치
 				int agentIndex = roundRobinIdx.getAndIncrement() % availableAgents.size();
 				DeliveryAgent assignedAgent = availableAgents.get(agentIndex);
 
@@ -66,19 +66,14 @@ public class DeliveryDispatchService {
 				deliveryAgentRepository.save(assignedAgent);
 				log.info("경로 배차 완료: agentId = {}, route = {}", assignedAgent.getDeliveryAgentId(), route);
 
-				DeliveryAgentAssignedEvent assignedEvent = new DeliveryAgentAssignedEvent(
-					event.deliveryId(),
-					assignedAgent.getDeliveryAgentId()
-				);
+				DeliveryAgentAssignedEvent assignedEvent = new DeliveryAgentAssignedEvent(event.deliveryId(),
+					assignedAgent.getDeliveryAgentId());
 				rabbitTemplate.convertAndSend(deliveryAssignedQueue, assignedEvent);
 				log.info("배달 서비스에 이벤트 발송: {}", assignedEvent);
 			}
-
 		} catch (Exception e) {
-			DeliveryFailedEvent failedEvent = new DeliveryFailedEvent(
-				event.deliveryId(),
-				ErrorCode.INVALID_DELIVERY_AGENT
-			);
+			DeliveryFailedEvent failedEvent = new DeliveryFailedEvent(event.deliveryId(),
+				ErrorCode.INVALID_DELIVERY_AGENT);
 			rabbitTemplate.convertAndSend(deliveryAssignedFailQueue, failedEvent);
 			log.error("배차 처리 중 오류 발생: event={}, 오류: {}", event, e.getMessage(), e);
 			throw e;  // 예외 메세지 처리
@@ -86,10 +81,24 @@ public class DeliveryDispatchService {
 
 	}
 
-	public record DeliveryFailedEvent(
-		UUID deliveryId,
-		ErrorCode errorCode
-	) {
+	private List<DeliveryAgent> getAvailableAgentsForRoute(RouteCreatedEvent.RouteInfo route) {
+		UUID startHubId = route.startHubId();
+		if (startHubId != null && hubFeignClient.existsById(startHubId)) {
+			// 허브가 존재하면 hubId가 일치하는 HUB_AGENT 우선 조회
+			List<DeliveryAgent> hubAgents = deliveryAgentRepository.findByDeliveryAgentStatusAndHubIdAndDeliveryAgentType(
+				DeliveryAgentStatus.AVAILABLE, startHubId, DeliveryAgentType.HUB_AGENT);
+			if (!hubAgents.isEmpty()) {
+				return hubAgents;
+			}
+			// 허브가 있지만 HUB_AGENT가 없으면 COMPANY_AGENT도 허용
+			return deliveryAgentRepository.findByDeliveryAgentStatus(DeliveryAgentStatus.AVAILABLE);
+		}
+		// startHubId가 없거나 허브가 없으면 COMPANY_AGENT만 조회
+		return deliveryAgentRepository.findByDeliveryAgentStatusAndDeliveryAgentType(DeliveryAgentStatus.AVAILABLE,
+			DeliveryAgentType.COMPANY_AGENT);
+	}
+
+	public record DeliveryFailedEvent(UUID deliveryId, ErrorCode errorCode) {
 	}
 }
 

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryDispatchService.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryDispatchService.java
@@ -1,6 +1,7 @@
 package com.eighteenthstreet.deliveryagentservice.application;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -29,6 +30,9 @@ public class DeliveryDispatchService {
 
 	@Value("${message.queue.delivery-assigned}")
 	private String deliveryAssignedQueue;
+
+	@Value("${message.queue.delivery-agent-failed}")
+	private String deliveryAssignedFailQueue;
 
 	@RabbitListener(queues = "${message.queue.route}")
 	public void handleRouteCratedEvent(RouteCreatedEvent event) {
@@ -71,11 +75,23 @@ public class DeliveryDispatchService {
 			}
 
 		} catch (Exception e) {
+			DeliveryFailedEvent failedEvent = new DeliveryFailedEvent(
+				event.deliveryId(),
+				ErrorCode.INVALID_DELIVERY_AGENT
+			);
+			rabbitTemplate.convertAndSend(deliveryAssignedFailQueue, failedEvent);
 			log.error("배차 처리 중 오류 발생: event={}, 오류: {}", event, e.getMessage(), e);
 			throw e;  // 예외 메세지 처리
 		}
 
 	}
 
+	public record DeliveryFailedEvent(
+		UUID deliveryId,
+		ErrorCode errorCode
+	) {
+	}
 }
+
+
 

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/client/HubFeignClient.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/client/HubFeignClient.java
@@ -1,0 +1,13 @@
+package com.eighteenthstreet.deliveryagentservice.application.client;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "hub-service")
+public interface HubFeignClient {
+	@GetMapping("/api/v1/hub/{hubId}/exists")
+	boolean existsById(@PathVariable("hubId") UUID hubId);
+}

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/dto/CreateDeliveryAgentResponse.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/dto/CreateDeliveryAgentResponse.java
@@ -1,36 +1,36 @@
 package com.eighteenthstreet.deliveryagentservice.application.dto;
 
+import java.util.UUID;
+
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgent;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentStatus;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Builder
 public class CreateDeliveryAgentResponse {
-    private UUID deliveryAgentId;
-    private UUID hubId;
-    private UUID userId;
-    private String slackId;
-    private DeliveryAgentType agentType;
-    private DeliveryAgentStatus agentStatus;
+	private UUID deliveryAgentId;
+	private UUID hubId;
+	private UUID userId;
+	private String slackId;
+	private DeliveryAgentType agentType;
+	private DeliveryAgentStatus agentStatus;
 
-
-    public static CreateDeliveryAgentResponse fromEntity(DeliveryAgent deliveryAgent) {
-        return CreateDeliveryAgentResponse.builder()
-                .deliveryAgentId(deliveryAgent.getDeliveryAgentId())
-                .hubId(deliveryAgent.getHubId())
-                .userId(deliveryAgent.getUserId())
-                .slackId(deliveryAgent.getSlackId())
-                .agentType(deliveryAgent.getDeliveryAgentType())
-                .agentStatus(deliveryAgent.getDeliveryAgentStatus())
-                .build();
-    }
+	public static CreateDeliveryAgentResponse fromEntity(DeliveryAgent deliveryAgent) {
+		return CreateDeliveryAgentResponse.builder()
+			.deliveryAgentId(deliveryAgent.getDeliveryAgentId())
+			.hubId(deliveryAgent.getHubId())
+			.userId(deliveryAgent.getUserId())
+			.slackId(deliveryAgent.getSlackId())
+			.agentType(deliveryAgent.getDeliveryAgentType())
+			.agentStatus(deliveryAgent.getDeliveryAgentStatus())
+			.build();
+	}
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/dto/GetDeliveryAgentResponse.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/dto/GetDeliveryAgentResponse.java
@@ -1,36 +1,36 @@
 package com.eighteenthstreet.deliveryagentservice.application.dto;
 
+import java.util.UUID;
+
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgent;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentStatus;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class GetDeliveryAgentResponse {
-    private UUID deliveryAgentId;
-    private UUID hubId;
-    private UUID userId;
-    private String slackId;
-    private DeliveryAgentType agentType;
-    private DeliveryAgentStatus agentStatus;
+	private UUID deliveryAgentId;
+	private UUID hubId;
+	private UUID userId;
+	private String slackId;
+	private DeliveryAgentType agentType;
+	private DeliveryAgentStatus agentStatus;
 
-
-    public static GetDeliveryAgentResponse fromEntity(DeliveryAgent deliveryAgent) {
-        return GetDeliveryAgentResponse.builder()
-                .deliveryAgentId(deliveryAgent.getDeliveryAgentId())
-                .hubId(deliveryAgent.getHubId())
-                .userId(deliveryAgent.getUserId())
-                .slackId(deliveryAgent.getSlackId())
-                .agentType(deliveryAgent.getDeliveryAgentType())
-                .agentStatus(deliveryAgent.getDeliveryAgentStatus())
-                .build();
-    }
+	public static GetDeliveryAgentResponse fromEntity(DeliveryAgent deliveryAgent) {
+		return GetDeliveryAgentResponse.builder()
+			.deliveryAgentId(deliveryAgent.getDeliveryAgentId())
+			.hubId(deliveryAgent.getHubId())
+			.userId(deliveryAgent.getUserId())
+			.slackId(deliveryAgent.getSlackId())
+			.agentType(deliveryAgent.getDeliveryAgentType())
+			.agentStatus(deliveryAgent.getDeliveryAgentStatus())
+			.build();
+	}
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/event/DeliveryAgentAssignedEvent.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/event/DeliveryAgentAssignedEvent.java
@@ -2,8 +2,5 @@ package com.eighteenthstreet.deliveryagentservice.domain.event;
 
 import java.util.UUID;
 
-public record DeliveryAgentAssignedEvent(
-	UUID deliveryId,
-	UUID deliveryAgentId
-) {
+public record DeliveryAgentAssignedEvent(UUID deliveryId, UUID deliveryAgentId) {
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/exception/DeliveryAgentNotFoundException.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/exception/DeliveryAgentNotFoundException.java
@@ -1,10 +1,11 @@
 package com.eighteenthstreet.deliveryagentservice.domain.exception;
 
 import com.eighteenthstreet.deliveryagentservice.presentation.exception.error.CustomException;
+
 import exception.ErrorCode;
 
 public class DeliveryAgentNotFoundException extends CustomException {
-    public DeliveryAgentNotFoundException(ErrorCode code) {
-        super(code);
-    }
+	public DeliveryAgentNotFoundException(ErrorCode code) {
+		super(code);
+	}
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/exception/InvalidDeliveryAgentException.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/exception/InvalidDeliveryAgentException.java
@@ -1,10 +1,11 @@
 package com.eighteenthstreet.deliveryagentservice.domain.exception;
 
 import com.eighteenthstreet.deliveryagentservice.presentation.exception.error.CustomException;
+
 import exception.ErrorCode;
 
 public class InvalidDeliveryAgentException extends CustomException {
-    public InvalidDeliveryAgentException(ErrorCode errorCode) {
-        super(errorCode);
-    }
+	public InvalidDeliveryAgentException(ErrorCode errorCode) {
+		super(errorCode);
+	}
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/model/DeliveryAgentStatus.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/model/DeliveryAgentStatus.java
@@ -1,5 +1,5 @@
 package com.eighteenthstreet.deliveryagentservice.domain.model;
 
 public enum DeliveryAgentStatus {
-    AVAILABLE, IN_DELIVERY, OFFLINE
+	AVAILABLE, IN_DELIVERY, OFFLINE
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/model/DeliveryAgentType.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/model/DeliveryAgentType.java
@@ -1,6 +1,6 @@
 package com.eighteenthstreet.deliveryagentservice.domain.model;
 
 public enum DeliveryAgentType {
-    COMPANY_AGENT,  // 업체 배달 담당자
-    HUB_AGENT     // 허브 배달 담당자
+	COMPANY_AGENT,  // 업체 배달 담당자
+	HUB_AGENT     // 허브 배달 담당자
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/repository/DeliveryAgentRepository.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/domain/repository/DeliveryAgentRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgent;
 import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentStatus;
+import com.eighteenthstreet.deliveryagentservice.domain.model.DeliveryAgentType;
 
 public interface DeliveryAgentRepository {
 	DeliveryAgent save(DeliveryAgent deliveryAgent);
@@ -15,4 +16,10 @@ public interface DeliveryAgentRepository {
 	List<DeliveryAgent> findByDeliveryAgentStatus(DeliveryAgentStatus status);
 
 	List<DeliveryAgent> findByDeliveryId(UUID deliveryId);
+
+	List<DeliveryAgent> findByDeliveryAgentStatusAndHubIdAndDeliveryAgentType(DeliveryAgentStatus deliveryAgentStatus,
+		UUID hubId, DeliveryAgentType deliveryAgentType);
+
+	List<DeliveryAgent> findByDeliveryAgentStatusAndDeliveryAgentType(DeliveryAgentStatus deliveryAgentStatus,
+		DeliveryAgentType deliveryAgentType);
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/infrastructure/rabbitmq/DeliveryAgentQueueConfig.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/infrastructure/rabbitmq/DeliveryAgentQueueConfig.java
@@ -25,6 +25,9 @@ public class DeliveryAgentQueueConfig {
 	@Value("${message.queue.delivery-assigned}")
 	private String queueAssigned;
 
+	@Value("${message.queue.delivery-agent-failed}")
+	private String queueAgentFailed;
+
 	@Bean
 	public TopicExchange exchange() {
 		return new TopicExchange(exchange);
@@ -41,6 +44,11 @@ public class DeliveryAgentQueueConfig {
 	}
 
 	@Bean
+	public Queue queueAgentFailed() {
+		return new Queue(queueAgentFailed);
+	}
+
+	@Bean
 	public Binding bindingRoute() {
 		return BindingBuilder.bind(queueRoute()).to(exchange()).with(queueRoute);
 	}
@@ -48,5 +56,10 @@ public class DeliveryAgentQueueConfig {
 	@Bean
 	public Binding bindingAssigned() {
 		return BindingBuilder.bind(queueRoute()).to(exchange()).with(queueAssigned);
+	}
+
+	@Bean
+	public Binding bindingFailed() {
+		return BindingBuilder.bind(queueAgentFailed()).to(exchange()).with(queueAgentFailed);
 	}
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/presentation/exception/GlobalExceptionHandler.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/presentation/exception/GlobalExceptionHandler.java
@@ -1,18 +1,19 @@
 package com.eighteenthstreet.deliveryagentservice.presentation.exception;
 
-import com.eighteenthstreet.deliveryagentservice.presentation.exception.error.CustomException;
-import exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.eighteenthstreet.deliveryagentservice.presentation.exception.error.CustomException;
+
+import exception.ErrorResponse;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(new ErrorResponse(e.getErrorCode()));
-    }
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(new ErrorResponse(e.getErrorCode()));
+	}
 
 }

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/presentation/exception/error/CustomException.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/presentation/exception/error/CustomException.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
+	private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-    }
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
 }

--- a/delivery-agent-service/src/main/resources/application.yml
+++ b/delivery-agent-service/src/main/resources/application.yml
@@ -59,6 +59,7 @@ message:
     delivery: delivery.delivery
     route: delivery.route
     delivery-assigned: delivery.assigned
+    delivery-agent-failed: delivery.agent.failed
   err:
     exchange: delivery.err
     queue:

--- a/delivery-agent-service/src/main/resources/application.yml
+++ b/delivery-agent-service/src/main/resources/application.yml
@@ -35,6 +35,12 @@ spring:
     port: 5672
     username: guest
     password: guest
+    listener:
+      simple:
+        retry:
+          enabled: true
+          max-attempts: 3
+          initial-interval: 5000ms
 
 
 eureka:

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
@@ -67,10 +67,8 @@ public class DeliveryRouteService {
 				DeliveryRoute saveRoute = deliveryRouteRepository.save(deliveryRoute);
 				log.info("경로 저장: {}", saveRoute);
 
-				routeInfos.add(
-					new RouteCreatedEvent.RouteInfo(saveRoute.getDeliveryRouteId(), sequence++,
-						route.getDepartureHub().getHubId(),
-						route.getArrivalHub().getHubId()));
+				routeInfos.add(new RouteCreatedEvent.RouteInfo(saveRoute.getDeliveryRouteId(), sequence++,
+					route.getDepartureHub().getHubId(), route.getArrivalHub().getHubId()));
 			}
 
 			// 3. 배차 시작하라고 메시지 보내기
@@ -78,8 +76,8 @@ public class DeliveryRouteService {
 			rabbitTemplate.convertAndSend(queue, routeEvent);
 			log.info("##### 배차 요청 보냄: {}", routeEvent);
 		} catch (FeignException.NotFound e) {
-			log.error("경로를 찾을 수 없음: startHubId={}, endHubId={}, 오류: {}",
-				event.getStartHubId(), event.getEndHubId(), e.getMessage());
+			log.error("경로를 찾을 수 없음: startHubId={}, endHubId={}, 오류: {}", event.getStartHubId(), event.getEndHubId(),
+				e.getMessage());
 			sendFailureEvent(event.getDeliveryId(), ErrorCode.DELIVERY_ROUTE_NOT_FOUND);
 		} catch (Exception e) {
 			log.error("예상치 못한 오류 발생: event={}, 오류: {}", event, e.getMessage(), e);
@@ -89,9 +87,8 @@ public class DeliveryRouteService {
 	}
 
 	public GetDeliveryRouteResponse getDeliveryRoutes(UUID deliveryAgentId) {
-		DeliveryRoute deliveryRoute = deliveryRouteRepository.findById(deliveryAgentId).orElseThrow(
-			() -> new DeliveryRouteNotFoundException(ErrorCode.DELIVERY_ROUTE_NOT_FOUND)
-		);
+		DeliveryRoute deliveryRoute = deliveryRouteRepository.findById(deliveryAgentId)
+			.orElseThrow(() -> new DeliveryRouteNotFoundException(ErrorCode.DELIVERY_ROUTE_NOT_FOUND));
 
 		return GetDeliveryRouteResponse.fromEntity(deliveryRoute);
 	}
@@ -100,20 +97,15 @@ public class DeliveryRouteService {
 	public List<DeliveryRouteDto> getDeliveryRoutesByDeliveryId(UUID deliveryId) {
 		List<DeliveryRoute> routes = deliveryRouteRepository.findByDeliveryId(deliveryId);
 		return routes.stream()
-			.map(route -> new DeliveryRouteDto(
-				route.getDeliveryRouteId(),
-				route.getSequence(),
-				route.getStartHubId(),
-				route.getEndHubId()
-			))
+			.map(route -> new DeliveryRouteDto(route.getDeliveryRouteId(), route.getSequence(), route.getStartHubId(),
+				route.getEndHubId()))
 			.toList();
 	}
 
 	@Transactional
 	public void deleteDeliveryRoute(UUID deliveryAgentId) {
-		DeliveryRoute deliveryRoute = deliveryRouteRepository.findById(deliveryAgentId).orElseThrow(
-			() -> new DeliveryRouteNotFoundException(ErrorCode.DELIVERY_ROUTE_NOT_FOUND)
-		);
+		DeliveryRoute deliveryRoute = deliveryRouteRepository.findById(deliveryAgentId)
+			.orElseThrow(() -> new DeliveryRouteNotFoundException(ErrorCode.DELIVERY_ROUTE_NOT_FOUND));
 
 		deliveryRoute.softDelete();
 	}

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/event/DeliveryCreatedEvent.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/event/DeliveryCreatedEvent.java
@@ -1,16 +1,16 @@
 package com.eighteenthstreet.deliveryrouteservice.domain.event;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class DeliveryCreatedEvent {
-    private UUID startHubId;
-    private UUID endHubId;
-    private UUID deliveryId;
+	private UUID startHubId;
+	private UUID endHubId;
+	private UUID deliveryId;
 }

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/exception/DeliveryRouteNotFoundException.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/exception/DeliveryRouteNotFoundException.java
@@ -1,10 +1,11 @@
 package com.eighteenthstreet.deliveryrouteservice.domain.exception;
 
 import com.eighteenthstreet.deliveryrouteservice.presentation.exception.error.CustomException;
+
 import exception.ErrorCode;
 
 public class DeliveryRouteNotFoundException extends CustomException {
-    public DeliveryRouteNotFoundException(ErrorCode errorCode) {
-        super(errorCode);
-    }
+	public DeliveryRouteNotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
 }

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/infrastructure/repository/JpaDeliveryRouteRepository.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/infrastructure/repository/JpaDeliveryRouteRepository.java
@@ -1,10 +1,11 @@
 package com.eighteenthstreet.deliveryrouteservice.infrastructure.repository;
 
-import com.eighteenthstreet.deliveryrouteservice.domain.model.DeliveryRoute;
-import com.eighteenthstreet.deliveryrouteservice.domain.repository.DeliveryRouteRepository;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
+import com.eighteenthstreet.deliveryrouteservice.domain.model.DeliveryRoute;
+import com.eighteenthstreet.deliveryrouteservice.domain.repository.DeliveryRouteRepository;
 
 public interface JpaDeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID>, DeliveryRouteRepository {
 }

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/presentation/DeliveryRouteController.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/presentation/DeliveryRouteController.java
@@ -1,37 +1,37 @@
 package com.eighteenthstreet.deliveryrouteservice.presentation;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
 
-import com.eighteenthstreet.deliveryrouteservice.application.DeliveryRouteService;
-import com.eighteenthstreet.deliveryrouteservice.application.dto.GetDeliveryRouteResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.UUID;
+import com.eighteenthstreet.deliveryrouteservice.application.DeliveryRouteService;
+import com.eighteenthstreet.deliveryrouteservice.application.dto.GetDeliveryRouteResponse;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 public class DeliveryRouteController {
-    private final DeliveryRouteService deliveryRouteService;
+	private final DeliveryRouteService deliveryRouteService;
 
-    @GetMapping("/{id}")
-    public ResponseEntity<GetDeliveryRouteResponse> getDeliveryRoute(@PathVariable("id") UUID deliveryAgentId) {
-        GetDeliveryRouteResponse response = deliveryRouteService.getDeliveryRoutes(deliveryAgentId);
+	@GetMapping("/{id}")
+	public ResponseEntity<GetDeliveryRouteResponse> getDeliveryRoute(@PathVariable("id") UUID deliveryAgentId) {
+		GetDeliveryRouteResponse response = deliveryRouteService.getDeliveryRoutes(deliveryAgentId);
 
-        return ResponseEntity.ok(response);
-    }
+		return ResponseEntity.ok(response);
+	}
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, String>> deleteDeliveryRoute(@PathVariable("id") UUID deliveryAgentId) {
-        deliveryRouteService.deleteDeliveryRoute(deliveryAgentId);
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Map<String, String>> deleteDeliveryRoute(@PathVariable("id") UUID deliveryAgentId) {
+		deliveryRouteService.deleteDeliveryRoute(deliveryAgentId);
 
-        return ResponseEntity.ok(Collections.singletonMap("message", "배달경로가 삭제되었습니다."));
-    }
-
+		return ResponseEntity.ok(Collections.singletonMap("message", "배달경로가 삭제되었습니다."));
+	}
 
 }

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/presentation/exception/GlobalExceptionHandler.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/presentation/exception/GlobalExceptionHandler.java
@@ -1,18 +1,19 @@
 package com.eighteenthstreet.deliveryrouteservice.presentation.exception;
 
-import com.eighteenthstreet.deliveryrouteservice.presentation.exception.error.CustomException;
-import exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.eighteenthstreet.deliveryrouteservice.presentation.exception.error.CustomException;
+
+import exception.ErrorResponse;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(new ErrorResponse(e.getErrorCode()));
-    }
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(new ErrorResponse(e.getErrorCode()));
+	}
 
 }

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/presentation/exception/error/CustomException.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/presentation/exception/error/CustomException.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
+	private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-    }
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryEventService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryEventService.java
@@ -27,9 +27,8 @@ public class DeliveryEventService {
 		log.info("DeliveryAgentEvent 수신 {}", event);
 
 		try {
-			Delivery delivery = deliveryRepository.findById(event.deliveryId()).orElseThrow(
-				() -> new DeliveryNotFoundException(ErrorCode.DELIVERY_NOT_FOUND)
-			);
+			Delivery delivery = deliveryRepository.findById(event.deliveryId())
+				.orElseThrow(() -> new DeliveryNotFoundException(ErrorCode.DELIVERY_NOT_FOUND));
 
 			delivery.setStatus(DeliveryStatus.OUT_FOR_DELIVERY);  // 상태 변경
 

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryEventService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryEventService.java
@@ -2,8 +2,10 @@ package com.eighteenthstreet.deliveryservice.application;
 
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eighteenthstreet.deliveryservice.domain.event.DeliveryAgentAssignedEvent;
+import com.eighteenthstreet.deliveryservice.domain.event.DeliveryFailedEvent;
 import com.eighteenthstreet.deliveryservice.domain.event.DeliveryRouteCreationFailedEvent;
 import com.eighteenthstreet.deliveryservice.domain.exception.DeliveryNotFoundException;
 import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
@@ -41,7 +43,28 @@ public class DeliveryEventService {
 	}
 
 	@RabbitListener(queues = "${message.queue.failed}")
+	@Transactional
 	public void handleDeliveryRouteCreationFailed(DeliveryRouteCreationFailedEvent event) {
+		Delivery delivery = deliveryRepository.findById(event.deliveryId()).orElseThrow(
+			() -> new DeliveryNotFoundException(ErrorCode.DELIVERY_NOT_FOUND)
+		);
+
+		delivery.failed();
+		deliveryRepository.save(delivery);
+
 		log.info("배송 경로 생성 실패 이벤트 수신: {}", event);
+	}
+
+	@RabbitListener(queues = "${message.queue.delivery-agent-failed}")
+	@Transactional
+	public void handleDeliveryAgentCreationFailed(DeliveryFailedEvent event) {
+		Delivery delivery = deliveryRepository.findById(event.deliveryId()).orElseThrow(
+			() -> new DeliveryNotFoundException(ErrorCode.DELIVERY_NOT_FOUND)
+		);
+
+		delivery.failed();
+		deliveryRepository.save(delivery);
+
+		log.info("배송 담당자 실패 이벤트 수신: {}", event);
 	}
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
@@ -125,12 +125,8 @@ public class DeliveryService {
 			Map<Integer, DeliveryRouteDto> routeMap = routes.stream()
 				.collect(Collectors.toMap(DeliveryRouteDto::getRouteSequence, route -> route));
 			List<DeliveryAgentDto> agentsWithRoutes = agentsWithoutRoutes.stream()
-				.map(agent -> new DeliveryAgentDto(
-					agent.getDeliveryAgentId(),
-					agent.getStatus(),
-					agent.getAgentSequence(),
-					routeMap.get(agent.getAgentSequence())
-				))
+				.map(agent -> new DeliveryAgentDto(agent.getDeliveryAgentId(), agent.getStatus(),
+					agent.getAgentSequence(), routeMap.get(agent.getAgentSequence())))
 				.collect(Collectors.toList());
 
 			// 4. 응답 조합

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/dto/CreateDeliveryResponse.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/dto/CreateDeliveryResponse.java
@@ -1,10 +1,15 @@
 package com.eighteenthstreet.deliveryservice.application.dto;
 
+import java.util.UUID;
+
 import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
 import com.eighteenthstreet.deliveryservice.domain.model.DeliveryStatus;
-import lombok.*;
 
-import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -12,20 +17,20 @@ import java.util.UUID;
 @Setter
 @Builder
 public class CreateDeliveryResponse {
-    private UUID deliveryId;
-    private UUID orderId;
-    private UUID startHubId;
-    private UUID endHubId;
-    private DeliveryStatus status;
+	private UUID deliveryId;
+	private UUID orderId;
+	private UUID startHubId;
+	private UUID endHubId;
+	private DeliveryStatus status;
 
-    public static CreateDeliveryResponse fromEntity(Delivery delivery) {
-        return CreateDeliveryResponse.builder()
-                .deliveryId(delivery.getDeliveryId())
-                .orderId(delivery.getOrderId())
-                .startHubId(delivery.getStartHubId())
-                .endHubId(delivery.getEndHubId())
-                .status(delivery.getStatus())
-                .build();
-    }
+	public static CreateDeliveryResponse fromEntity(Delivery delivery) {
+		return CreateDeliveryResponse.builder()
+			.deliveryId(delivery.getDeliveryId())
+			.orderId(delivery.getOrderId())
+			.startHubId(delivery.getStartHubId())
+			.endHubId(delivery.getEndHubId())
+			.status(delivery.getStatus())
+			.build();
+	}
 
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/dto/GetDeliveryResponse.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/dto/GetDeliveryResponse.java
@@ -1,10 +1,15 @@
 package com.eighteenthstreet.deliveryservice.application.dto;
 
+import java.util.UUID;
+
 import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
 import com.eighteenthstreet.deliveryservice.domain.model.DeliveryStatus;
-import lombok.*;
 
-import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -12,19 +17,19 @@ import java.util.UUID;
 @Setter
 @Builder
 public class GetDeliveryResponse {
-    private UUID deliveryId;
-    private UUID orderId;
-    private UUID startHubId;
-    private UUID endHubId;
-    private DeliveryStatus status;
+	private UUID deliveryId;
+	private UUID orderId;
+	private UUID startHubId;
+	private UUID endHubId;
+	private DeliveryStatus status;
 
-    public static GetDeliveryResponse fromEntity(Delivery delivery) {
-        return GetDeliveryResponse.builder()
-                .deliveryId(delivery.getDeliveryId())
-                .orderId(delivery.getOrderId())
-                .startHubId(delivery.getStartHubId())
-                .endHubId(delivery.getEndHubId())
-                .status(delivery.getStatus())
-                .build();
-    }
+	public static GetDeliveryResponse fromEntity(Delivery delivery) {
+		return GetDeliveryResponse.builder()
+			.deliveryId(delivery.getDeliveryId())
+			.orderId(delivery.getOrderId())
+			.startHubId(delivery.getStartHubId())
+			.endHubId(delivery.getEndHubId())
+			.status(delivery.getStatus())
+			.build();
+	}
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/event/DeliveryCreatedEvent.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/event/DeliveryCreatedEvent.java
@@ -1,17 +1,16 @@
 package com.eighteenthstreet.deliveryservice.domain.event;
 
+import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class DeliveryCreatedEvent {
-    private UUID startHubId;
-    private UUID endHubId;
-    private UUID deliveryId;
+	private UUID startHubId;
+	private UUID endHubId;
+	private UUID deliveryId;
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/event/DeliveryFailedEvent.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/event/DeliveryFailedEvent.java
@@ -1,0 +1,11 @@
+package com.eighteenthstreet.deliveryservice.domain.event;
+
+import java.util.UUID;
+
+import exception.ErrorCode;
+
+public record DeliveryFailedEvent(
+	UUID deliveryId,
+	ErrorCode errorCode
+) {
+}

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/exception/DeliveryNotFoundException.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/exception/DeliveryNotFoundException.java
@@ -1,10 +1,11 @@
 package com.eighteenthstreet.deliveryservice.domain.exception;
 
 import com.eighteenthstreet.deliveryservice.presentation.exception.error.CustomException;
+
 import exception.ErrorCode;
 
 public class DeliveryNotFoundException extends CustomException {
-    public DeliveryNotFoundException(ErrorCode code) {
-        super(code);
-    }
+	public DeliveryNotFoundException(ErrorCode code) {
+		super(code);
+	}
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/exception/InvalidDeliveryException.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/exception/InvalidDeliveryException.java
@@ -1,10 +1,11 @@
 package com.eighteenthstreet.deliveryservice.domain.exception;
 
 import com.eighteenthstreet.deliveryservice.presentation.exception.error.CustomException;
+
 import exception.ErrorCode;
 
 public class InvalidDeliveryException extends CustomException {
-    public InvalidDeliveryException(ErrorCode code) {
-        super(code);
-    }
+	public InvalidDeliveryException(ErrorCode code) {
+		super(code);
+	}
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/Delivery.java
@@ -69,6 +69,10 @@ public class Delivery extends BaseEntity {
 		this.status = DeliveryStatus.CANCELED;
 	}
 
+	public void failed() {
+		this.status = DeliveryStatus.DELIVERY_FAIL;
+	}
+
 	public static Delivery createDelivery(CreateDeliveryRequest createDeliveryRequest) {
 		return Delivery.builder()
 			.startHubId(createDeliveryRequest.getStartHubId())

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/Delivery.java
@@ -28,7 +28,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@SQLRestriction("deleted_at IS NULL")
+@SQLRestriction("deleted_at IS NULL AND status <> 'DELIVERY_FAIL'")
 @Table(name = "p_delivery")
 public class Delivery extends BaseEntity {
 

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/DeliveryStatus.java
@@ -7,6 +7,5 @@ public enum DeliveryStatus {
 	ARRIVED_AT_HUB,       // 목적지 허브 도착
 	OUT_FOR_DELIVERY,     // 배송중
 	IN_TRANSIT_TO_VENDOR, // 업체 이동중
-	CANCELED,
-	DELIVERED;           // 배송완료
+	CANCELED, DELIVERED;           // 배송완료
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/repository/DeliveryRepository.java
@@ -1,13 +1,13 @@
 package com.eighteenthstreet.deliveryservice.domain.repository;
 
-import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
-
 import java.util.Optional;
 import java.util.UUID;
 
-public interface DeliveryRepository {
-    Delivery save(Delivery delivery);
+import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
 
-    Optional<Delivery> findById(UUID uuid);
+public interface DeliveryRepository {
+	Delivery save(Delivery delivery);
+
+	Optional<Delivery> findById(UUID uuid);
 
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/rabbitmq/DeliveryQueueConfig.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/rabbitmq/DeliveryQueueConfig.java
@@ -38,6 +38,9 @@ public class DeliveryQueueConfig {
 	@Value("${message.err.queue.route}")
 	private String queueErrRoute;
 
+	@Value("${message.queue.delivery-agent-failed}")
+	private String queueAgentFailed;
+
 	@Bean
 	public TopicExchange exchange() {
 		return new TopicExchange(exchange);
@@ -54,8 +57,13 @@ public class DeliveryQueueConfig {
 	}
 
 	@Bean
+	public Queue queueAgentFailed() {
+		return new Queue(queueAgentFailed);
+	}
+
+	@Bean
 	public Queue queueFailed() {
-		return new Queue(queueFailed); // "delivery.failed"
+		return new Queue(queueFailed);
 	}
 
 	@Bean
@@ -99,5 +107,10 @@ public class DeliveryQueueConfig {
 	@Bean
 	public Binding bindingErrRoute() {
 		return BindingBuilder.bind(queueErrRoute()).to(exchangeErr()).with(queueErrRoute);
+	}
+
+	@Bean
+	public Binding bindingAssignedFailed() {
+		return BindingBuilder.bind(queueAgentFailed()).to(exchange()).with(queueAgentFailed);
 	}
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/repository/JpaDeliveryRepository.java
@@ -1,12 +1,12 @@
 package com.eighteenthstreet.deliveryservice.infrastructure.repository;
 
-import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
-import com.eighteenthstreet.deliveryservice.domain.repository.DeliveryRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.UUID;
 
-public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID>, DeliveryRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
+import com.eighteenthstreet.deliveryservice.domain.repository.DeliveryRepository;
+
+public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID>, DeliveryRepository {
 
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/presentation/DeliveryController.java
@@ -28,11 +28,8 @@ import lombok.RequiredArgsConstructor;
 public class DeliveryController {
 	private final DeliveryService deliveryService;
 
-	//TODO: 전체적으로 gateWay 가 생기면 jwt 를 받는 헤더를 추가 할 예정, 예외처리도 할 예정
-
 	@PostMapping()
-	public ResponseEntity<CreateDeliveryResponse> createDelivery(
-		@RequestBody CreateDeliveryRequest request) {
+	public ResponseEntity<CreateDeliveryResponse> createDelivery(@RequestBody CreateDeliveryRequest request) {
 		CreateDeliveryResponse response = deliveryService.createDelivery(request);
 
 		return ResponseEntity.ok(response);

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/presentation/exception/GlobalExceptionHandler.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/presentation/exception/GlobalExceptionHandler.java
@@ -18,8 +18,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-			.body(new ErrorResponse(e.getErrorCode()));
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(new ErrorResponse(e.getErrorCode()));
 	}
 
 	@ExceptionHandler(CustomFeignException.class)

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/presentation/exception/error/CustomException.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/presentation/exception/error/CustomException.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
+	private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-    }
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
 }

--- a/delivery-service/src/main/resources/application.yml
+++ b/delivery-service/src/main/resources/application.yml
@@ -50,6 +50,8 @@ message:
     route: delivery.route
     delivery-assigned: delivery.assigned
     failed: delivery.failed
+    delivery-agent-failed: delivery.agent.failed
+
   err:
     exchange: delivery.err
     queue:

--- a/hub-service/src/main/java/com/eighteenthstreet/hub_service/application/HubService.java
+++ b/hub-service/src/main/java/com/eighteenthstreet/hub_service/application/HubService.java
@@ -1,15 +1,10 @@
 package com.eighteenthstreet.hub_service.application;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,5 +87,9 @@ public class HubService {
 			.orElseThrow(() -> new CustomHubNotFoundException(ErrorCode.HUB_NOT_FOUND));
 
 		foundHub.performSoftDelete();
+	}
+
+	public boolean existsById(UUID hubId) {
+		return hubRepository.existsById(hubId);
 	}
 }

--- a/hub-service/src/main/java/com/eighteenthstreet/hub_service/domain/HubRepository.java
+++ b/hub-service/src/main/java/com/eighteenthstreet/hub_service/domain/HubRepository.java
@@ -19,4 +19,6 @@ public interface HubRepository {
 	Page<Hub> findByNameContaining(String keyword, Pageable pageable);
 
 	Optional<Hub> findById(UUID hubId);
+
+	boolean existsById(UUID hubId);
 }

--- a/hub-service/src/main/java/com/eighteenthstreet/hub_service/presentation/HubController.java
+++ b/hub-service/src/main/java/com/eighteenthstreet/hub_service/presentation/HubController.java
@@ -1,6 +1,5 @@
 package com.eighteenthstreet.hub_service.presentation;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +20,6 @@ import com.eighteenthstreet.hub_service.application.HubService;
 import com.eighteenthstreet.hub_service.application.dto.CreateHubResponse;
 import com.eighteenthstreet.hub_service.application.dto.GetHubResponse;
 import com.eighteenthstreet.hub_service.application.dto.UpdateHubResponse;
-import com.eighteenthstreet.hub_service.domain.model.Hub;
 import com.eighteenthstreet.hub_service.presentation.request.CreateHubRequest;
 import com.eighteenthstreet.hub_service.presentation.request.UpdateHubRequest;
 
@@ -72,8 +70,8 @@ public class HubController {
 	}
 
 	@PutMapping("/{hubId}")
-	public ResponseEntity<UpdateHubResponse> updateHub(@PathVariable UUID hubId, @RequestBody UpdateHubRequest request)
-	{
+	public ResponseEntity<UpdateHubResponse> updateHub(@PathVariable UUID hubId,
+		@RequestBody UpdateHubRequest request) {
 		UpdateHubResponse response = hubService.updateHub(hubId, request);
 
 		return ResponseEntity.status(HttpStatus.OK).body(response);
@@ -84,5 +82,10 @@ public class HubController {
 		hubService.deleteHub(hubId);
 
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@GetMapping("/{hubId}/exists")
+	public boolean existsById(@PathVariable("hubId") UUID hubId) {
+		return hubService.existsById(hubId);
 	}
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 리팩토링

## 변경 내용
- **as-is**
    - 배차 API 실패 시 이벤트 처리가 없었음.
    - 배달 상태가 실패(DELIVERY_FAIL)인 경우에 대한 조회 차단 처리가 없었음.
    - 허브 존재 여부 확인을 위한 별도의 API가 없음.
    - 허브 담당자 배차 시 허브 ID 검증이 없었음.

- **to-be**
    - 배차 API 실패 시 메시지 큐를 통해 Delivery-Service로 실패 이벤트 전달.
    - 배달 상태가 실패(DELIVERY_FAIL)인 경우 조회를 차단하는 SQL 제한 추가.
    - `Hub-Service`에 허브 존재 여부를 확인하는 API 추가.
    - Delivery-Service에서 허브가 존재하는지 확인하는 HubClient 추가.
    - 허브 담당자 우선 배차 및 허브 ID 검증 기능 추가.

## 코멘트
- `Hub-Service` 에 변경사항이 있습니다 확인해주세용
- 허브 담당자 우선 배차 및 허브 ID 검증 기능을 통해 유효한 허브 ID만을 사용하도록 처리.
- 배달 상태가 실패한 경우 조회를 차단하여 잘못된 데이터를 방지.