### PR TITLE
Feature/delivery refactor

### DIFF
--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryDispatchService.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/application/DeliveryDispatchService.java
@@ -37,7 +37,7 @@ public class DeliveryDispatchService {
 	@Value("${message.queue.delivery-agent-failed}")
 	private String deliveryAssignedFailQueue;
 
-	@RabbitListener(queues = "${message.queue.route}")
+	@RabbitListener(queues = "${message.queue.delivery-route}")
 	public void handleRouteCratedEvent(RouteCreatedEvent event) {
 		log.info("배달담당서비스 요청 받음: {}", event);
 

--- a/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/infrastructure/rabbitmq/DeliveryAgentQueueConfig.java
+++ b/delivery-agent-service/src/main/java/com/eighteenthstreet/deliveryagentservice/infrastructure/rabbitmq/DeliveryAgentQueueConfig.java
@@ -19,7 +19,7 @@ public class DeliveryAgentQueueConfig {
 	@Value("${message.exchange}")
 	private String exchange;
 
-	@Value("${message.queue.route}")
+	@Value("${message.queue.delivery-route}")
 	private String queueRoute;
 
 	@Value("${message.queue.delivery-assigned}")

--- a/delivery-agent-service/src/main/resources/application.yml
+++ b/delivery-agent-service/src/main/resources/application.yml
@@ -60,14 +60,12 @@ management:
 
 
 message:
-  exchange: delivery
+  exchange: logistics
   queue:
-    delivery: delivery.delivery
-    route: delivery.route
-    delivery-assigned: delivery.assigned
-    delivery-agent-failed: delivery.agent.failed
+    delivery-route: logistics.delivery-route
+    delivery-assigned: logistics.assigned
+    delivery-agent-failed: logistics.agent-failed
   err:
-    exchange: delivery.err
+    exchange: logistics.err
     queue:
-      err:
-        delivery: delivery.err.delivery
+      route: logistics.err.route

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
@@ -31,17 +31,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DeliveryRouteService {
 
-	@Value("${message.queue.route}")
+	@Value("${message.queue.delivery-route}")
 	private String queue;
 
-	@Value("${message.queue.failed}")
+	@Value("${message.queue.delivery-route-failed}")
 	private String failedQueue;
 
 	private final DeliveryRouteRepository deliveryRouteRepository;
 	private final RabbitTemplate rabbitTemplate;
 	private final HubRouteClient hubRouteClient;
 
-	@RabbitListener(queues = "${message.queue.delivery}")
+	@RabbitListener(queues = "${message.queue.delivery-service}")
 	@Transactional
 	public void createDeliveryRoute(DeliveryCreatedEvent event) {
 		log.info("######### 배송 요청 받음: {}", event);

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
@@ -80,9 +80,10 @@ public class DeliveryRouteService {
 			rabbitTemplate.convertAndSend(queue, routeEvent);
 			log.info("##### 배차 요청 보냄: {}", routeEvent);
 
-			// 4. 주문 측에 배달 생성 메세지 보내기
-			OrderDeliveryCompleteMessage orderMessage = new OrderDeliveryCompleteMessage(event.getDeliveryId(),
-				event.getOrderId());
+			// 4. 주문 측에 완료 메세지 보내기
+			OrderDeliveryCompleteMessage orderMessage = new OrderDeliveryCompleteMessage(event.getOrderId(),
+				event.getDeliveryId());
+			log.info("###### 주문 측에 성공 메세지 보냄: {}", orderMessage);
 			rabbitTemplate.convertAndSend(completeOrderQueue, orderMessage);
 
 		} catch (FeignException.NotFound e) {

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/application/DeliveryRouteService.java
@@ -16,6 +16,7 @@ import com.eighteenthstreet.deliveryrouteservice.application.client.HubRouteClie
 import com.eighteenthstreet.deliveryrouteservice.application.dto.DeliveryRouteDto;
 import com.eighteenthstreet.deliveryrouteservice.application.dto.GetDeliveryRouteResponse;
 import com.eighteenthstreet.deliveryrouteservice.domain.event.DeliveryCreatedEvent;
+import com.eighteenthstreet.deliveryrouteservice.domain.event.OrderDeliveryCompleteMessage;
 import com.eighteenthstreet.deliveryrouteservice.domain.exception.DeliveryRouteNotFoundException;
 import com.eighteenthstreet.deliveryrouteservice.domain.model.DeliveryRoute;
 import com.eighteenthstreet.deliveryrouteservice.domain.repository.DeliveryRouteRepository;
@@ -36,6 +37,9 @@ public class DeliveryRouteService {
 
 	@Value("${message.queue.delivery-route-failed}")
 	private String failedQueue;
+
+	@Value("${message.complete.queue.order}")
+	private String completeOrderQueue;
 
 	private final DeliveryRouteRepository deliveryRouteRepository;
 	private final RabbitTemplate rabbitTemplate;
@@ -75,6 +79,12 @@ public class DeliveryRouteService {
 			RouteCreatedEvent routeEvent = new RouteCreatedEvent(event.getDeliveryId(), routeInfos);
 			rabbitTemplate.convertAndSend(queue, routeEvent);
 			log.info("##### 배차 요청 보냄: {}", routeEvent);
+
+			// 4. 주문 측에 배달 생성 메세지 보내기
+			OrderDeliveryCompleteMessage orderMessage = new OrderDeliveryCompleteMessage(event.getDeliveryId(),
+				event.getOrderId());
+			rabbitTemplate.convertAndSend(completeOrderQueue, orderMessage);
+
 		} catch (FeignException.NotFound e) {
 			log.error("경로를 찾을 수 없음: startHubId={}, endHubId={}, 오류: {}", event.getStartHubId(), event.getEndHubId(),
 				e.getMessage());

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/event/DeliveryCreatedEvent.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/event/DeliveryCreatedEvent.java
@@ -13,4 +13,5 @@ public class DeliveryCreatedEvent {
 	private UUID startHubId;
 	private UUID endHubId;
 	private UUID deliveryId;
+	private UUID orderId;
 }

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/event/OrderDeliveryCompleteMessage.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/domain/event/OrderDeliveryCompleteMessage.java
@@ -1,0 +1,9 @@
+package com.eighteenthstreet.deliveryrouteservice.domain.event;
+
+import java.util.UUID;
+
+public record OrderDeliveryCompleteMessage(
+	UUID orderId,
+	UUID deliveryId
+) {
+}

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/infrastructure/rabbitmq/DeliveryRouteQueueConfig.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/infrastructure/rabbitmq/DeliveryRouteQueueConfig.java
@@ -15,13 +15,13 @@ public class DeliveryRouteQueueConfig {
 	@Value("${message.exchange}")
 	private String exchange;
 
-	@Value("${message.queue.delivery}")
+	@Value("${message.queue.delivery-service}")
 	private String queueDelivery;
 
-	@Value("${message.queue.route}")
+	@Value("${message.queue.delivery-route}")
 	private String queueRoute;
 
-	@Value("${message.queue.failed}")
+	@Value("${message.queue.delivery-route-failed}")
 	private String queueFailed;
 
 	@Value("${message.err.exchange}")

--- a/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/infrastructure/rabbitmq/DeliveryRouteQueueConfig.java
+++ b/delivery-route-service/src/main/java/com/eighteenthstreet/deliveryrouteservice/infrastructure/rabbitmq/DeliveryRouteQueueConfig.java
@@ -15,6 +15,9 @@ public class DeliveryRouteQueueConfig {
 	@Value("${message.exchange}")
 	private String exchange;
 
+	@Value("${message.complete.exchange}")
+	private String completeExchange;
+
 	@Value("${message.queue.delivery-service}")
 	private String queueDelivery;
 
@@ -30,6 +33,9 @@ public class DeliveryRouteQueueConfig {
 	@Value("${message.err.queue.route}")
 	private String queueErrRoute;
 
+	@Value("${message.complete.queue.order}")
+	private String queueCompleteOrder;
+
 	@Bean
 	public Jackson2JsonMessageConverter producerJackson2MessageConverter() {
 		return new Jackson2JsonMessageConverter();
@@ -41,10 +47,20 @@ public class DeliveryRouteQueueConfig {
 		return new TopicExchange(exchange); // "delivery"
 	}
 
+	@Bean
+	public TopicExchange completeExchange() {
+		return new TopicExchange(completeExchange);
+	}
+
 	// 큐 정의
 	@Bean
 	public Queue queueDelivery() {
 		return new Queue(queueDelivery); // "delivery.delivery"
+	}
+
+	@Bean
+	public Queue queueCompleteOrder() {
+		return new Queue(queueCompleteOrder);
 	}
 
 	@Bean
@@ -89,5 +105,10 @@ public class DeliveryRouteQueueConfig {
 	@Bean
 	public Binding bindingErrRoute() {
 		return BindingBuilder.bind(queueErrRoute()).to(exchangeErr()).with(queueErrRoute);
+	}
+
+	@Bean
+	public Binding bindingCompleteOrder() {
+		return BindingBuilder.bind(queueCompleteOrder()).to(completeExchange()).with(queueCompleteOrder);
 	}
 }

--- a/delivery-route-service/src/main/resources/application.yml
+++ b/delivery-route-service/src/main/resources/application.yml
@@ -52,6 +52,10 @@ message:
     exchange: logistics.err
     queue:
       route: logistics.err.route
+  complete:
+    exchange: logistics.complete
+    queue:
+      order: logistics.complete.order
 
 
 eureka:

--- a/delivery-route-service/src/main/resources/application.yml
+++ b/delivery-route-service/src/main/resources/application.yml
@@ -43,15 +43,15 @@ spring:
           initial-interval: 5000ms
 
 message:
-  exchange: delivery                   # 기본 익스체인지
+  exchange: logistics                   # 기본 익스체인지
   queue:
-    delivery: delivery.delivery        # 배송 요청 큐
-    route: delivery.route              # 배차 요청 큐
-    failed: delivery.failed            # 실패 이벤트 큐 (delivery-service로 전달)
+    delivery-service: logistics.delivery-service   # 배송 요청 큐
+    delivery-route: logistics.delivery-route            # 배차 요청 큐
+    delivery-route-failed: logistics.route-failed      # 실패 이벤트 큐 (delivery-service로 전달)
   err:
-    exchange: delivery.err
+    exchange: logistics.err
     queue:
-      route: delivery.err.route
+      route: logistics.err.route
 
 
 eureka:

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryEventService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryEventService.java
@@ -41,7 +41,7 @@ public class DeliveryEventService {
 
 	}
 
-	@RabbitListener(queues = "${message.queue.failed}")
+	@RabbitListener(queues = "${message.queue.delivery-route-failed}")
 	@Transactional
 	public void handleDeliveryRouteCreationFailed(DeliveryRouteCreationFailedEvent event) {
 		Delivery delivery = deliveryRepository.findById(event.deliveryId()).orElseThrow(

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
@@ -49,7 +49,7 @@ public class DeliveryService {
 		delivery = deliveryRepository.save(delivery);
 
 		DeliveryCreatedEvent event = new DeliveryCreatedEvent(createDeliveryRequest.getStartHubId(),
-			createDeliveryRequest.getEndHubId(), delivery.getDeliveryId());
+			createDeliveryRequest.getEndHubId(), delivery.getDeliveryId(), UUID.randomUUID());
 		log.info("######### Send Message[Delivery] : {}", event);
 		rabbitTemplate.convertAndSend(queueDelivery, event);
 		return CreateDeliveryResponse.fromEntity(delivery);
@@ -61,7 +61,7 @@ public class DeliveryService {
 		delivery = deliveryRepository.save(delivery);
 
 		DeliveryCreatedEvent event = new DeliveryCreatedEvent(message.startHubId(),
-			message.endHubId(), delivery.getDeliveryId());
+			message.endHubId(), delivery.getDeliveryId(), message.orderId());
 		log.info("######### Send Message[Delivery Message] : {}", event);
 		rabbitTemplate.convertAndSend(queueDelivery, event);
 		return CreateDeliveryResponse.fromEntity(delivery);

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
@@ -22,6 +22,7 @@ import com.eighteenthstreet.deliveryservice.domain.event.DeliveryCreatedEvent;
 import com.eighteenthstreet.deliveryservice.domain.exception.DeliveryNotFoundException;
 import com.eighteenthstreet.deliveryservice.domain.model.Delivery;
 import com.eighteenthstreet.deliveryservice.domain.repository.DeliveryRepository;
+import com.eighteenthstreet.deliveryservice.infrastructure.messaging.message.DeliveryMessage;
 import com.eighteenthstreet.deliveryservice.presentation.exception.error.CustomException;
 import com.eighteenthstreet.deliveryservice.presentation.request.CreateDeliveryRequest;
 import com.eighteenthstreet.deliveryservice.presentation.request.UpdateStatusDeliveryRequest;
@@ -50,6 +51,18 @@ public class DeliveryService {
 		DeliveryCreatedEvent event = new DeliveryCreatedEvent(createDeliveryRequest.getStartHubId(),
 			createDeliveryRequest.getEndHubId(), delivery.getDeliveryId());
 		log.info("######### Send Message[Delivery] : {}", event);
+		rabbitTemplate.convertAndSend(queueDelivery, event);
+		return CreateDeliveryResponse.fromEntity(delivery);
+	}
+
+	public CreateDeliveryResponse createMessageDelivery(DeliveryMessage message) {
+		Delivery delivery = Delivery.createMessageDelivery(message);
+
+		delivery = deliveryRepository.save(delivery);
+
+		DeliveryCreatedEvent event = new DeliveryCreatedEvent(message.startHubId(),
+			message.endHubId(), delivery.getDeliveryId());
+		log.info("######### Send Message[Delivery Message] : {}", event);
 		rabbitTemplate.convertAndSend(queueDelivery, event);
 		return CreateDeliveryResponse.fromEntity(delivery);
 	}
@@ -131,4 +144,5 @@ public class DeliveryService {
 			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
+
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/application/DeliveryService.java
@@ -39,7 +39,7 @@ public class DeliveryService {
 	private final DeliveryRouteClient deliveryRouteClient;
 	private final DeliveryAgentClient deliveryAgentClient;
 
-	@Value("${message.queue.delivery}")
+	@Value("${message.queue.delivery-service}")
 	private String queueDelivery;
 
 	public CreateDeliveryResponse createDelivery(CreateDeliveryRequest createDeliveryRequest) {

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/event/DeliveryCreatedEvent.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/event/DeliveryCreatedEvent.java
@@ -13,4 +13,5 @@ public class DeliveryCreatedEvent {
 	private UUID startHubId;
 	private UUID endHubId;
 	private UUID deliveryId;
+	private UUID orderId;
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/domain/model/Delivery.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
 
 import com.eighteenthstreet.deliveryservice.domain.exception.InvalidDeliveryException;
+import com.eighteenthstreet.deliveryservice.infrastructure.messaging.message.DeliveryMessage;
 import com.eighteenthstreet.deliveryservice.presentation.request.CreateDeliveryRequest;
 
 import base.BaseEntity;
@@ -83,4 +84,16 @@ public class Delivery extends BaseEntity {
 			.status(DeliveryStatus.PENDING_AT_HUB)
 			.build();
 	}
+
+	public static Delivery createMessageDelivery(DeliveryMessage message) {
+		return Delivery.builder()
+			.startHubId(message.startHubId())
+			.endHubId(message.endHubId())
+			.orderId(message.orderId())
+			.recipient(message.ordererId())
+			.destinationAddress(message.destinationAddress())
+			.status(DeliveryStatus.PENDING_AT_HUB)
+			.build();
+	}
+
 }

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/messaging/DeliveryMessageListener.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/messaging/DeliveryMessageListener.java
@@ -1,0 +1,27 @@
+package com.eighteenthstreet.deliveryservice.infrastructure.messaging;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import com.eighteenthstreet.deliveryservice.application.DeliveryService;
+import com.eighteenthstreet.deliveryservice.application.dto.CreateDeliveryResponse;
+import com.eighteenthstreet.deliveryservice.infrastructure.messaging.message.DeliveryMessage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeliveryMessageListener {
+	private final DeliveryService deliveryService;
+
+	@RabbitListener(queues = "${message.queue.delivery}")
+	public ResponseEntity<CreateDeliveryResponse> createDelivery(DeliveryMessage message) {
+		log.info("#### Delivery Message 수신 {} ", message);
+		CreateDeliveryResponse response = deliveryService.createMessageDelivery(message);
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/messaging/message/DeliveryMessage.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/messaging/message/DeliveryMessage.java
@@ -1,0 +1,12 @@
+package com.eighteenthstreet.deliveryservice.infrastructure.messaging.message;
+
+import java.util.UUID;
+
+public record DeliveryMessage(
+	UUID orderId,
+	UUID startHubId,
+	UUID endHubId,
+	UUID ordererId,
+	String destinationAddress
+) {
+}

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/rabbitmq/DeliveryQueueConfig.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/rabbitmq/DeliveryQueueConfig.java
@@ -20,16 +20,16 @@ public class DeliveryQueueConfig {
 	@Value("${message.exchange}")
 	private String exchange;
 
-	@Value("${message.queue.delivery}")
+	@Value("${message.queue.delivery-service}")
 	private String queueDelivery;
 
-	@Value("${message.queue.route}")
+	@Value("${message.queue.delivery-route}")
 	private String queueRoute;
 
 	@Value("${message.queue.delivery-assigned}")
 	private String queueAssigned;
 
-	@Value("${message.queue.failed}")
+	@Value("${message.queue.delivery-route-failed}")
 	private String queueFailed;
 
 	@Value("${message.err.exchange}")

--- a/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/rabbitmq/DeliveryQueueConfig.java
+++ b/delivery-service/src/main/java/com/eighteenthstreet/deliveryservice/infrastructure/rabbitmq/DeliveryQueueConfig.java
@@ -20,6 +20,9 @@ public class DeliveryQueueConfig {
 	@Value("${message.exchange}")
 	private String exchange;
 
+	@Value("${message.queue.delivery}")
+	private String queueOrderDelivery;
+
 	@Value("${message.queue.delivery-service}")
 	private String queueDelivery;
 
@@ -46,6 +49,10 @@ public class DeliveryQueueConfig {
 		return new TopicExchange(exchange);
 	}
 
+	public Queue queueOrderDelivery() {
+		return new Queue(queueOrderDelivery);
+	}
+
 	@Bean
 	public Queue queueDelivery() {
 		return new Queue(queueDelivery);
@@ -69,6 +76,11 @@ public class DeliveryQueueConfig {
 	@Bean
 	public Queue queueAssigned() {
 		return new Queue(queueAssigned);
+	}
+
+	@Bean
+	public Binding bindingOrderDelivery() {
+		return BindingBuilder.bind(queueOrderDelivery()).to(exchange()).with(queueOrderDelivery);
 	}
 
 	@Bean

--- a/delivery-service/src/main/resources/application.yml
+++ b/delivery-service/src/main/resources/application.yml
@@ -44,19 +44,17 @@ spring:
 
 
 message:
-  exchange: delivery
+  exchange: logistics
   queue:
-    delivery: delivery.delivery
-    route: delivery.route
-    delivery-assigned: delivery.assigned
-    failed: delivery.failed
-    delivery-agent-failed: delivery.agent.failed
-
+    delivery-service: logistics.delivery-service
+    delivery-route: logistics.delivery-route
+    delivery-assigned: logistics.assigned
+    delivery-route-failed: logistics.route-failed
+    delivery-agent-failed: logistics.agent-failed
   err:
-    exchange: delivery.err
+    exchange: logistics.err
     queue:
-      route: delivery.err.route
-
+      route: logistics.err.route
 
 eureka:
   client:

--- a/delivery-service/src/main/resources/application.yml
+++ b/delivery-service/src/main/resources/application.yml
@@ -46,6 +46,7 @@ spring:
 message:
   exchange: logistics
   queue:
+    delivery: logistics.delivery
     delivery-service: logistics.delivery-service
     delivery-route: logistics.delivery-route
     delivery-assigned: logistics.assigned


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 리팩토링

## 변경 내용
- **as-is**
    - Delivery 서비스가 Order 서비스의 메시지를 수신하지 않음
    - 기존 DeliveryEvent에서 `orderId` 필드가 포함되지 않음
    - 일부 이벤트 인스턴스 생성 순서 오류 발생

- **to-be**
    - Delivery 서비스가 Order 서비스로부터 메시지를 받아 이벤트를 생성하도록 수정
    - `DeliveryCreatedEvent` DTO에 `orderId` 필드 추가
    - 기존 이벤트에도 `orderId` 추가하여 데이터 일관성 유지
    - Event 인스턴스 생성 순서 오류 수정

## 코멘트
- 메시지 큐 구조를 정리하면서 Order → Delivery 메시지 전달 기능 추가
- 기존 메시지 처리 로직에는 영향을 주지 않으며, 이벤트 데이터 구조 개선
- 추가적으로 관련 문서를 업데이트하면 좋을 것 같음