### PR TITLE
Feat/slack/refactor

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,19 @@ services:
     environment:
       - JAVA_OPTS=-Xms512m -Xmx512m
 
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    restart: always
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - app_network
+    environment:
+      RABBITMQ_DEFAULT_USER: quest
+      RABBITMQ_DEFAULT_PASS: quest
+
 networks:
   app_network:
     driver: bridge

--- a/gateway-service/src/main/java/com/eighteenthstreet/gateway_service/InternalAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/eighteenthstreet/gateway_service/InternalAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.eighteenthstreet.gateway_service;
+
+import java.time.Instant;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class InternalAuthenticationFilter implements GlobalFilter, Ordered {
+	@Value("${JWT_SECRET_KEY}")
+	private String secretKey;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		String path = exchange.getRequest().getURI().getPath();
+		log.info("path = {}", path);
+		// "/internal/" 경로일 경우에만 내부 JWT 삽입
+		if (path.startsWith("/internal/")) {
+			String token = createInternalToken();
+
+			ServerHttpRequest newRequest = exchange.getRequest().mutate()
+				.header("Authorization", "Bearer " + token)
+				.build();
+
+			return chain.filter(exchange.mutate().request(newRequest).build());
+		}
+
+		return chain.filter(exchange);
+	}
+
+	@Override
+	public int getOrder() {
+		return -10;
+	}
+
+	private String createInternalToken() {
+		SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+
+		return Jwts.builder()
+			.subject("internal-service")
+			.issuer("gateway")
+			.audience().add("user-service").and()
+			.claim("role", "internal")
+			.expiration(Date.from(Instant.now().plusSeconds(600))) // 10분 유효
+			.signWith(key)
+			.compact();
+	}
+}

--- a/gateway-service/src/main/java/com/eighteenthstreet/gateway_service/JwtAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/eighteenthstreet/gateway_service/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -24,7 +25,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-public class JwtAuthenticationFilter implements GlobalFilter {
+public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final JwtUtil jwtUtil;
 
@@ -34,16 +35,12 @@ public class JwtAuthenticationFilter implements GlobalFilter {
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String path = exchange.getRequest().getURI().getPath();
-		String internalCallHeader = exchange.getRequest().getHeaders().getFirst("X-Internal-Call");
 
-		// 내부 호출일 경우 인증 스킵
-		if ("true".equalsIgnoreCase(internalCallHeader)) {
-			log.info("내부 호출");
-			return chain.filter(exchange);
+		if (path.startsWith("/internal/")) {
+			return chain.filter(exchange); // 내부 요청은 인증 스킵
 		}
 
-		if (path.equals("/api/v1/users/signUp") || path.equals("/api/v1/users/signIn") || path.startsWith(
-			"/api/v1/users/incall/detail")) {
+		if (path.equals("/api/v1/users/signUp") || path.equals("/api/v1/users/signIn")) {
 			return chain.filter(exchange);
 		}
 
@@ -124,5 +121,10 @@ public class JwtAuthenticationFilter implements GlobalFilter {
 			.parseSignedClaims(token)
 			.getBody();
 		return claims.get("role", String.class);
+	}
+
+	@Override
+	public int getOrder() {
+		return 0;
 	}
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -36,6 +36,10 @@ spring:
           uri: lb://user-service
           predicates:
             - Path=/api/v1/users/**
+        - id: user-service-internal
+          uri: lb://user-service
+          predicates:
+            - Path=/internal/users/**
         - id: hub-service
           uri: lb://hub-service
           predicates:

--- a/slack-service/src/main/java/com/eighteenthstreet/slack_service/application/client/UserServiceClient.java
+++ b/slack-service/src/main/java/com/eighteenthstreet/slack_service/application/client/UserServiceClient.java
@@ -5,15 +5,13 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 import com.eighteenthstreet.slack_service.application.dto.UserResponseDto;
 
-@FeignClient(name = "user-service")
+@FeignClient(name = "user-service", url = "http://localhost:19091")
 public interface UserServiceClient {
-	@GetMapping("/api/v1/users/incall/detail/{userId}")
-	UserResponseDto getUser(
-		@PathVariable("userId") UUID userId,
-		@RequestHeader("X-Internal-Call") String internalHeader // 추가
+	@GetMapping("/internal/users/{userId}")
+	UserResponseDto getUserInternal(
+		@PathVariable("userId") UUID userId
 	);
 }

--- a/slack-service/src/main/java/com/eighteenthstreet/slack_service/application/service/SlackService.java
+++ b/slack-service/src/main/java/com/eighteenthstreet/slack_service/application/service/SlackService.java
@@ -169,7 +169,7 @@ public class SlackService {
 		try {
 			log.info("userId: {}", userId);
 			// String token = util.getAccessTokenFromHeader();
-			return userServiceClient.getUser(userId, "true");
+			return userServiceClient.getUserInternal(userId);
 		} catch (CustomException e) {
 			throw new CustomException(ErrorCode.USER_GET_API_FAIL);
 		}

--- a/user-service/src/main/java/com/eighteenthstreet/user_service/application/service/UserService.java
+++ b/user-service/src/main/java/com/eighteenthstreet/user_service/application/service/UserService.java
@@ -131,7 +131,7 @@ public class UserService {
 		return userMapper.toUserResponseDto(targetUser);
 	}
 
-	public UserResponseDto getUserDetailIncall(UUID userId) {
+	public UserResponseDto getUserDetailInternal(UUID userId) {
 		User targetUser = userRepository.findByUserId(userId);
 		if (targetUser == null) {
 			throw new CustomException(ErrorCode.USER_NOT_FOUND);

--- a/user-service/src/main/java/com/eighteenthstreet/user_service/infrastructure/security/InternalJwtAuthFilter.java
+++ b/user-service/src/main/java/com/eighteenthstreet/user_service/infrastructure/security/InternalJwtAuthFilter.java
@@ -1,0 +1,62 @@
+package com.eighteenthstreet.user_service.infrastructure.security;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class InternalJwtAuthFilter extends OncePerRequestFilter {
+
+	@Value("${JWT_SECRET_KEY}")
+	private String secretKey;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String auth = request.getHeader("Authorization");
+		if (auth != null && auth.startsWith("Bearer ")) {
+			try {
+				SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+				Claims claims = Jwts.parser()
+					.verifyWith(key)
+					.build()
+					.parseSignedClaims(auth.substring(7))
+					.getBody();
+
+				// 내부 서비스 인증인지 확인
+				if ("gateway".equals(claims.getIssuer()) &&
+					"internal".equals(claims.get("role", String.class))) {
+
+					UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken("internal-service", null, List.of());
+					SecurityContextHolder.getContext().setAuthentication(authentication);
+				}
+
+			} catch (Exception e) {
+				log.warn("Internal JWT 검증 실패: {}", e.getMessage());
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/user-service/src/main/java/com/eighteenthstreet/user_service/infrastructure/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/eighteenthstreet/user_service/infrastructure/security/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http,
+		InternalJwtAuthFilter internalJwtAuthFilter) throws Exception {
 		http
 			// basic auth 및 csrf 보안을 사용하지 않음
 			.httpBasic(AbstractHttpConfigurer::disable)
@@ -40,7 +41,6 @@ public class SecurityConfig {
 				authorize -> authorize
 					.requestMatchers("/api/v1/users/signUp").permitAll()
 					.requestMatchers("/api/v1/users/signIn").permitAll()
-					.requestMatchers("/api/v1/users/incall/detail/**").permitAll()
 					.requestMatchers(
 						"/swagger-ui/**",
 						"/swagger-ui.html",
@@ -51,6 +51,7 @@ public class SecurityConfig {
 					).permitAll()
 					.anyRequest().authenticated()
 			)
+			.addFilterBefore(internalJwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(new UserAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 		return http.build();
 	}

--- a/user-service/src/main/java/com/eighteenthstreet/user_service/presentation/controller/InternalUserController.java
+++ b/user-service/src/main/java/com/eighteenthstreet/user_service/presentation/controller/InternalUserController.java
@@ -1,0 +1,29 @@
+package com.eighteenthstreet.user_service.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.eighteenthstreet.user_service.application.dto.UserResponseDto;
+import com.eighteenthstreet.user_service.application.service.UserService;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+
+@Hidden
+@RestController
+@RequestMapping("/internal/users")
+@RequiredArgsConstructor
+public class InternalUserController {
+
+	private final UserService userService;
+
+	@GetMapping("/{userId}")
+	public ResponseEntity<UserResponseDto> getUserForInternal(@PathVariable("userId") UUID userId) {
+		return ResponseEntity.ok(userService.getUserDetailInternal(userId));
+	}
+}

--- a/user-service/src/main/java/com/eighteenthstreet/user_service/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/eighteenthstreet/user_service/presentation/controller/UserController.java
@@ -124,13 +124,6 @@ public class UserController {
 		return ResponseEntity.ok(userService.getUserDetail(userId));
 	}
 
-	@Operation(summary = "사용자 상세 조회 (내부 조회)", description = "사용자 ID로 특정 사용자 정보를 조회합니다. (내부 조회)")
-	@GetMapping("/incall/detail/{userId}")
-	public ResponseEntity<UserResponseDto> getUserDetailIncall(
-		@Parameter(description = "조회할 사용자 ID") @PathVariable("userId") UUID userId) {
-		return ResponseEntity.ok(userService.getUserDetailIncall(userId));
-	}
-
 	@Operation(summary = "사용자 정보 수정", description = "마스터 권한으로 사용자 정보를 수정합니다.")
 	@PatchMapping("/{userId}")
 	@PreAuthorize("hasRole('MASTER')")


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - SecurityConfig에 user 조회 api 경로 그대로 permitAll() -> 보안 매우 취약

- **to-be**
    - /internal/users/** 로 분리하여 Gateway에서 해당 path인 경우 내부 토큰 만들어서 인증 처리되도록 로직 수정
    - 변경 Service : gateway-service, user-service, slack-service

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)